### PR TITLE
Upgrade gateway v5 to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ npm install
 create app
 https://discordapp.com/developers/applications/me
 
-auth app
+create bot user for your newly created app to get the token
+(see https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token for details and screenshots)
+
+auth app (change %% to the client_id given to your app)
 https://discordapp.com/oauth2/authorize?scope=bot&permissions=0&client_id=%%
 
 cp config.example.json config.json

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "gordonkabs",
   "license": "MIT",
   "dependencies": {
-    "discord.io": "^2.1.3",
+    "discord.io": "github:woor/discord.io#gateway_v6",
     "request": "^2.74.0"
   },
   "repository": {


### PR DESCRIPTION
This changes the API depency to switch to v6 gateway, since v5 was deprecated and shutdown.

Closes issue #3 


![bildschirmfoto vom 2017-12-13 21-21-44](https://user-images.githubusercontent.com/3312979/33960640-a4854f62-e04b-11e7-8666-2b365e0aa993.png)